### PR TITLE
詳細ページ

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,0 +1,6 @@
+class UsersController < ApplicationController
+  def show
+    @user = User.find(params[:id])
+    @prototypes = @user.prototypes
+  end
+end

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -1,0 +1,2 @@
+module UsersHelper
+end

--- a/app/views/prototypes/_prototype.html.erb
+++ b/app/views/prototypes/_prototype.html.erb
@@ -9,7 +9,7 @@
 
 
 
-      <%= link_to prototype.user.name, prototype_path(prototype.user), class: :card__user %>
+      <%= link_to prototype.user.name, user_path(prototype.user), class: :card__user %>
 
     </div>
   </div>

--- a/app/views/prototypes/index.html.erb
+++ b/app/views/prototypes/index.html.erb
@@ -5,15 +5,14 @@
 <% if user_signed_in? %>
   <div class="greeting">
     こんにちは、
-    <%= link_to "#{ current_user.name }さん" ,root_path,class: :greeting__link %>
-    
+    <%= link_to "#{current_user.name}さん", user_path(current_user), class: :greeting__link %>
    
   </div>
 <% end %>
 
     <div class="card__wrapper">
 
-      <%= render "prototype"%>
+      <%= render "prototype" , prototypes: @prototypes %>
     </div>
   </div>
 </main>

--- a/app/views/prototypes/show.html.erb
+++ b/app/views/prototypes/show.html.erb
@@ -5,7 +5,7 @@
         <%= @prototype.title %>
       </p>
 
-      <%= link_to "by #{@prototype.user.name}", root_path, class: :prototype__user %>
+      <%= link_to "by #{@prototype.user.name}", user_path(current_user), class: :prototype__user %>
       <% if user_signed_in? && current_user == @prototype.user %>
 
         <div class="prototype__manage">

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -2,25 +2,25 @@
   <div class="inner">
     <div class="user__wrapper">
       <h2 class="page-heading">
-        <%= "ユーザー名さんの情報"%>
+        <%= @user.name %>さんの情報
       </h2>
       <table class="table">
         <tbody>
           <tr>
             <th class="table__col1">名前</th>
-            <td class="table__col2"><%= "ユーザー名" %></td>
+            <td class="table__col2"><%= @user.name %></td>
           </tr>
           <tr>
             <th class="table__col1">プロフィール</th>
-            <td class="table__col2"><%= "ユーザーのプロフィール" %></td>
+            <td class="table__col2"><%= @user.profile %></td>
           </tr>
           <tr>
             <th class="table__col1">所属</th>
-            <td class="table__col2"><%= "ユーザーの所属" %></td>
+            <td class="table__col2"><%= @user.affiliation %></td>
           </tr>
           <tr>
             <th class="table__col1">役職</th>
-            <td class="table__col2"><%= "ユーザーの役職" %></td>
+            <td class="table__col2"><%= @user.position %></td>
           </tr>
         </tbody>
       </table>
@@ -28,7 +28,7 @@
         <%= "ユーザー名さんのプロトタイプ"%>
       </h2>
       <div class="user__card">
-        <%# 部分テンプレートでそのユーザーが投稿したプロトタイプ投稿一覧を表示する %>
+        <%=render'/prototypes/prototype' , prototypes: @user.prototypes %>
       </div>
     </div>
   </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,4 +8,5 @@ Rails.application.routes.draw do
   devise_scope :user do
       get '/users/sign_out' => 'devise/sessions#destroy'
   end
+  resources :users,only: :show
 end

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class UsersControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
### what
詳細ページの実装
### why
エラーがでたため作り直しました
- [ユーザー詳細表示ページは、ログイン状況に関係なく、誰でも見ることができること。](https://gyazo.com/326ee30179e49ba63c598541ddf7966c)
- [各ページのユーザー名をクリックすると、該当ユーザーの詳細ページへ遷移すること。](https://gyazo.com/5efe28f82d95ab55b33e1277ce0179aa)
- [ユーザーの詳細ページには、そのユーザーの詳細情報（名前・プロフィール・所属・役職）が表示されていること。](https://gyazo.com/ffc72e897b464b92e6b6e8edf101c55c)
- [ユーザーの詳細ページには、そのユーザーが投稿したプロトタイプの情報（プロトタイプ名・投稿者・画像・キャッチコピー・コンセプト）が表示されていること。](https://gyazo.com/15bb12841e95a8a0defa4eb444426be4)
- [プロトタイプ情報の画像が表示されており、画像がリンク切れなどになっていないこと（Renderの仕様による画像のリンク切れは、要件未達に含まれない。Render上では一定時間経過すると画像が消える。）](https://gyazo.com/c42ad83e63e43fcc08fccb55ff7b201a)
